### PR TITLE
Reduce Footer Visibility

### DIFF
--- a/themes/unsafe9/assets/css/main.css
+++ b/themes/unsafe9/assets/css/main.css
@@ -526,7 +526,7 @@ main.container {
 
 /* ===== Footer ===== */
 .footer {
-    background-color: var(--bg-secondary);
+    background-color: var(--bg-color);
     border-top: 1px solid var(--border-color);
     padding: 1rem 0;
     margin-top: auto;
@@ -539,11 +539,13 @@ main.container {
     padding: 0 1.5rem;
     text-align: center;
     color: var(--text-light);
+    opacity: 0.5;
+    font-size: 0.85rem;
 }
 
 .footer a {
-    color: var(--primary-color);
-    font-weight: 500;
+    color: var(--text-light);
+    font-weight: 400;
 }
 
 /* ===== No Content Messages ===== */


### PR DESCRIPTION
- Change background from secondary to main color (better blending)
- Add 50% opacity for subtle appearance
- Reduce font size to 0.85rem
- Change link color from primary blue to muted text-light
- Remove bold font weight from links

The footer is now much less distracting while remaining functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)